### PR TITLE
fix: sometimes datetime_str may be an empty string

### DIFF
--- a/google_photos_takeout_helper/__main__.py
+++ b/google_photos_takeout_helper/__main__.py
@@ -236,7 +236,7 @@ def main():
                 break
             except KeyError:
                 pass
-        if datetime_str is None:
+        if datetime_str is None or datetime_str == '':
             raise IOError('No DateTime in given exif')
         set_creation_date_from_str(file, datetime_str)
 

--- a/google_photos_takeout_helper/__main__.py
+++ b/google_photos_takeout_helper/__main__.py
@@ -236,7 +236,7 @@ def main():
                 break
             except KeyError:
                 pass
-        if datetime_str is None or datetime_str == '':
+        if datetime_str is None or datetime_str.strip() == '':
             raise IOError('No DateTime in given exif')
         set_creation_date_from_str(file, datetime_str)
 


### PR DESCRIPTION
Sometimes the photo may get an empty string date, I fixed it.

```shell
Error setting creation date from string:
time data '' does not match format '%Y:%m:%d %H:%M:%S'
Traceback (most recent call last):
  File "/usr/local/bin/google-photos-takeout-helper", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.9/site-packages/google_photos_takeout_helper/__main__.py", line 353, in main
    for_all_files_recursive(
  File "/usr/local/lib/python3.9/site-packages/google_photos_takeout_helper/__main__.py", line 99, in for_all_files_recursive
    for_all_files_recursive(file, file_function, folder_function, filter_fun)
  File "/usr/local/lib/python3.9/site-packages/google_photos_takeout_helper/__main__.py", line 102, in for_all_files_recursive
    file_function(dir, file)
  File "/usr/local/lib/python3.9/site-packages/google_photos_takeout_helper/__main__.py", line 274, in fix_metadata
    set_creation_date_from_exif(file)
  File "/usr/local/lib/python3.9/site-packages/google_photos_takeout_helper/__main__.py", line 241, in set_creation_date_from_exif
    set_creation_date_from_str(file, datetime_str)
  File "/usr/local/lib/python3.9/site-packages/google_photos_takeout_helper/__main__.py", line 226, in set_creation_date_from_str
    _os.utime(file, (timestamp, timestamp))
UnboundLocalError: local variable 'timestamp' referenced before assignment
```