### PR TITLE
Fix timedata error

### DIFF
--- a/google_photos_takeout_helper/__main__.py
+++ b/google_photos_takeout_helper/__main__.py
@@ -95,9 +95,9 @@ def main():
     photo_formats = ['.jpg', '.jpeg', '.png', '.webp', '.bmp', '.tif', '.tiff', '.svg', '.heic']
     video_formats = ['.mp4', '.gif', '.mov', '.webm', '.avi', '.wmv', '.rm', '.mpg', '.mpe', '.mpeg', '.m4v']
     extra_formats = [
-        '-edited', '-effects',  # EN/US
+        '-edited', '-effects', '-smile',  # EN/US
         '-edytowane',  # PL
-        # Add more "edited" flags in more languages if you want
+        # Add more "edited" flags in more languages if you want. They need to be lowercase
     ]
 
     _os.makedirs(FIXED_DIR, exist_ok=True)
@@ -238,13 +238,27 @@ def main():
             # Turns out exif can have different formats - YYYY:MM:DD, YYYY/..., YYYY-... etc
             # God wish that americans won't have something like MM-DD-YYYY
             str_datetime = str_datetime.replace('-', ':').replace('/', ':').replace('.', ':').replace('\\', ':')[:19]
+        except Exception as e:
+            print("Error fixing datetime string.")
+            print(e)
+
+        try:
             timestamp = _datetime.strptime(
                 str_datetime,
                 '%Y:%m:%d %H:%M:%S'
             ).timestamp()
-        except Exception as e:
-            print('Error setting creation date from string:')
-            print(e)
+        except Exception as e1:
+            try:
+                print("Looks like an error was thrown with an incorrect time string. Trying again differently...")
+                # Sometimes it reads the date wrong like so: 2006:11:09 10:54: 1.
+                # So if it throws an error, it will try again with a whitespace before the %S seconds.
+                timestamp = _datetime.strptime(
+                    str_datetime,
+                    '%Y:%m:%d %H:%M: %S'
+                ).timestamp()
+            except Exception as e2:
+                print('Error setting creation date from string:')
+                print(e2)
         _os.utime(file, (timestamp, timestamp))
 
     def set_creation_date_from_exif(file):

--- a/google_photos_takeout_helper/__main__.py
+++ b/google_photos_takeout_helper/__main__.py
@@ -237,28 +237,16 @@ def main():
         try:
             # Turns out exif can have different formats - YYYY:MM:DD, YYYY/..., YYYY-... etc
             # God wish that americans won't have something like MM-DD-YYYY
-            str_datetime = str_datetime.replace('-', ':').replace('/', ':').replace('.', ':').replace('\\', ':')[:19]
-        except Exception as e:
-            print("Error fixing datetime string.")
-            print(e)
-
-        try:
+            # The replace ': ' to ':0' fixes issues when it reads the string as 2006:11:09 10:54: 1.
+            # It replaces the extra whitespace with a 0 for proper parsing
+            str_datetime = str_datetime.replace('-', ':').replace('/', ':').replace('.', ':').replace('\\', ':').replace(': ', ':0')[:19]
             timestamp = _datetime.strptime(
                 str_datetime,
                 '%Y:%m:%d %H:%M:%S'
             ).timestamp()
-        except Exception as e1:
-            try:
-                print("Looks like an error was thrown with an incorrect time string. Trying again differently...")
-                # Sometimes it reads the date wrong like so: 2006:11:09 10:54: 1.
-                # So if it throws an error, it will try again with a whitespace before the %S seconds.
-                timestamp = _datetime.strptime(
-                    str_datetime,
-                    '%Y:%m:%d %H:%M: %S'
-                ).timestamp()
-            except Exception as e2:
-                print('Error setting creation date from string:')
-                print(e2)
+        except Exception as e:
+            print('Error setting creation date from string:')
+            print(e)
         _os.utime(file, (timestamp, timestamp))
 
     def set_creation_date_from_exif(file):

--- a/google_photos_takeout_helper/__main__.py
+++ b/google_photos_takeout_helper/__main__.py
@@ -95,9 +95,9 @@ def main():
     photo_formats = ['.jpg', '.jpeg', '.png', '.webp', '.bmp', '.tif', '.tiff', '.svg', '.heic']
     video_formats = ['.mp4', '.gif', '.mov', '.webm', '.avi', '.wmv', '.rm', '.mpg', '.mpe', '.mpeg', '.m4v']
     extra_formats = [
-        '-edited', '-effects', '-smile',  # EN/US
+        '-edited', '-effects', '-smile', '-mix',  # EN/US
         '-edytowane',  # PL
-        # Add more "edited" flags in more languages if you want. They need to be lowercase
+        # Add more "edited" flags in more languages if you want. They need to be lowercase.
     ]
 
     _os.makedirs(FIXED_DIR, exist_ok=True)

--- a/google_photos_takeout_helper/__main__.py
+++ b/google_photos_takeout_helper/__main__.py
@@ -216,7 +216,11 @@ def main():
     # Returns date in 2019:01:01 23:59:59 format
     def get_date_from_folder_name(dir):
         dir = _os.path.basename(_os.path.normpath(dir))
-        dir = dir[:10].replace('-', ':') + ' 12:00:00'
+        dir = dir[:10].replace('-', ':').replace(' ', ':') + ' 12:00:00'
+
+        # Sometimes google exports folders without the -, like 2009 08 30...
+        # So the end result would be 2009 08 30 12:00:00, which does not match the format.
+        # Therefore, we also replace the spaces with ':'
 
         # Reformat it to check if it matcher, and quit if doesn't match - it's probably a date folder
         try:


### PR DESCRIPTION
I would get an error on some files when it would read the date time as `2006:11:09 10:54: 1`. It couldn't handle the extra whitespace before the seconds. So I added another replace to fix it. 