### PR TITLE
Refactor duplication and Add Albums

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,27 +54,9 @@ Now, you should be able to just run it straight in cmd/terminal:
 
 If you want your photos to be divided by year and month, run it with `--divide-to-dates` flag.
 
-Unless you specify, --keep-duplicates, duplicate images with the same picture, the same exif data, and in the same output directory will only keep a single copy around and delete the rest. This will happen to identical files even if they have different names.
+// (For now, info about albums is saved in `/ORIGINAL_INPUT_FOLDER/albums.json`)
 
-Album data will currently only be represented in the albums.json file in the following format:
-{
-  "your-album-name": [
-     "IMG_1.jpg",
-     "IMG_2.png",
-     ...
-  ],
-  "your-second-album-name": [
-     "IMG_1.jpg",
-     "IMG_2.png",
-     ...
-  ],
-  ...
-}
-
-
-
-
-If you have issues/questions, you can hit me up either by [Reddit](https://www.reddit.com/user/TheLastGimbus/posts/), [Twitter](https://twitter.com/TheLastGimbus) Email: [google-photos-takeout-gh@niceyyyboyyy.anonaddy.com](mailto:google-photos-takeout-gh@niceyyyboyyy.anonaddy.com), or if you think your issue is common: [Issues](https://github.com/TheLastGimbus/GooglePhotosTakeoutHelper/issues) tab
+If you have issues/questions, you can hit me up either by [Reddit](https://www.reddit.com/user/TheLastGimbus/), [Twitter](https://twitter.com/TheLastGimbus) Email: [google-photos-takeout-gh@niceyyyboyyy.anonaddy.com](mailto:google-photos-takeout-gh@niceyyyboyyy.anonaddy.com), or if you think your issue is common: [Issues](https://github.com/TheLastGimbus/GooglePhotosTakeoutHelper/issues) tab
 
 </p>
 </details>

--- a/README.md
+++ b/README.md
@@ -90,4 +90,4 @@ https://github.com/HardFork/KeepToText
 ### TODO (Pull Requests welcome):
 - [ ] Videos' Exif data
 - [x] Gps data: from JSON to Exif - Thank you @DalenW :sparkling_heart:
-- [x] Some way to handle albums - Done!
+- [x] Some way to handle albums - THANK YOU @bitsondatadev :kissing_heart: :tada: :woman_dancing: 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ It will take all of your photos from those tiny folders, set their `exif` and `l
 0. Get all your photos in [Google Takeout](https://takeout.google.com/) (select only Google Photos)
 1. `pip3 install -U google-photos-takeout-helper`
 2. Extract all contents from your Google Takeout to one folder
-3. Cut out/remove all ["album folders"](#why-do-you-need-to-cut-out-albums) that aren't named "2016-06-16" or something like that
-4. Run `google-photos-takeout-helper -i [INPUT TAKEOUT FOLDER] -o [OUTPUT FOLDER]`
+3. Run `google-photos-takeout-helper -i [INPUT TAKEOUT FOLDER] -o [OUTPUT FOLDER]`
 
 Alternatively, if you don't have PATH set right, you can call it `python3 -m google_photos_takeout_helper`
 
@@ -45,31 +44,40 @@ If something goes wrong and it prints some red errors, try to add ` --user` flag
 3. Prepare your Takeout:
 
 If your Takeout was dividied into multiple `.zip`s, you will need to extract them, and move their contents into one folder. 
-
-Because I don't have good solution on how to handle albums, you will need to cut off all ["Album folders"](#why-do-you-need-to-cut-out-albums) - those who are not named like "2016-06-26" or "2016-06-26 #2" - don't worry, all photos from albums are in corresponding "date folders" already - they would just make a duplicate.
-
 Now, you should be able to just run it straight in cmd/terminal:
 
 4. `google-photos-takeout-helper -i [INPUT TAKEOUT FOLDER] -o [OUTPUT FOLDER]`
 
 // Or if this doesn't work: `python3 -m google_photos_takeout_helper -i [INPUT TAKEOUT FOLDER] -o [OUTPUT FOLDER]`
 
-// Ps note: Jezus fucking Christ people, without the "[ ]" :facepalm:
+// Ps note: Don't use the "[ ]" in the command above.
 
 If you want your photos to be divided by year and month, run it with `--divide-to-dates` flag.
+
+Unless you specify, --keep-duplicates, duplicate images with the same picture, the same exif data, and in the same output directory will only keep a single copy around and delete the rest. This will happen to identical files even if they have different names.
+
+Album data will currently only be represented in the albums.json file in the following format:
+{
+  "your-album-name": [
+     "IMG_1.jpg",
+     "IMG_2.png",
+     ...
+  ],
+  "your-second-album-name": [
+     "IMG_1.jpg",
+     "IMG_2.png",
+     ...
+  ],
+  ...
+}
+
+
 
 
 If you have issues/questions, you can hit me up either by [Reddit](https://www.reddit.com/user/TheLastGimbus/posts/), [Twitter](https://twitter.com/TheLastGimbus) Email: [google-photos-takeout-gh@niceyyyboyyy.anonaddy.com](mailto:google-photos-takeout-gh@niceyyyboyyy.anonaddy.com), or if you think your issue is common: [Issues](https://github.com/TheLastGimbus/GooglePhotosTakeoutHelper/issues) tab
 
 </p>
 </details>
-
-### Why do you need to cut out albums?
-They mostly contain duplicates of same photos that are in corresponding "date folder". (Note: not ALL photos found in album folders will be duplicated in date folders. You should maintain a separate backup of the original Google Takeout folder/zip to ensure you don't lose any photos. See [Issue #22](https://github.com/TheLastGimbus/GooglePhotosTakeoutHelper/issues/22) for more details)
-This script tries to get all "photo taken time" stuff right. If it finds json - it sets everything from that json (it contains data of edited timestamp that you might've corrected in Google Photos). If it can't - it tries to get Exif data form photo.
-IF it can't find anything like that, it sets date from folder name.
-
-All of this is so that you can then safely store ALL of your photos in one folder, and they will all be in right order.
 
 #### Unless you move them around your Android phone. 
 Beware, that (99% of the times), if you move some files in Android, their creation and modification time is reseted to current.
@@ -83,7 +91,7 @@ https://github.com/SimpleMobileTools/Simple-Gallery
 
  - If you want something more centralized but also self-hosted, [Nextcloud](https://nextcloud.com) is a nice choice, but it's approach to photos is still not perfect. (And you need to set up your own server)
 
- - Guys at [Photoprims](https://photoprism.org/) are working on full Google Photos alternative, with search and AI tagging etc, but it's stil work in progress. (I will edit this when they are done, but can't promise :P ) 
+ - Guys at [Photoprism](https://photoprism.org/) are working on full Google Photos alternative, with search and AI tagging etc, but it's stil work in progress. (I will edit this when they are done, but can't promise :P ) 
 
 
 #### Other Takeout projects
@@ -100,4 +108,4 @@ https://github.com/HardFork/KeepToText
 ### TODO (Pull Requests welcome):
 - [ ] Videos' Exif data
 - [x] Gps data: from JSON to Exif - Thank you @DalenW :sparkling_heart:
-- [ ] Some way to handle albums - Kinda WIP in #10
+- [x] Some way to handle albums - Done!

--- a/google_photos_takeout_helper/__main__.py
+++ b/google_photos_takeout_helper/__main__.py
@@ -349,7 +349,7 @@ def main():
             ).timestamp()
             _os.utime(file, (timestamp, timestamp))
             if _os.name == 'nt':
-                _windoza_setctime.setctime()
+                _windoza_setctime.setctime(str(file), timestamp)
         except Exception as e:
             print('Error setting creation date from string:')
             print(e)

--- a/google_photos_takeout_helper/__main__.py
+++ b/google_photos_takeout_helper/__main__.py
@@ -88,13 +88,13 @@ def main():
         # Add more "edited" flags in more languages if you want. They need to be lowercase.
     ]
 
-    #Album Multimap
+    # Album Multimap
     album_mmap = _defaultdict(list)
 
-    #Duplicate by full hash multimap
+    # Duplicate by full hash multimap
     files_by_full_hash = _defaultdict(list)
 
-    #holds all the renamed files that clashed from their 
+    # holds all the renamed files that clashed from their
     rename_map = dict()
 
     meta_file_memo = dict()
@@ -158,7 +158,7 @@ def main():
             if not chunk:
                 return
             yield chunk
-    
+
     def get_hash(file: Path, first_chunk_only=False, hash_algo=_hashlib.sha1):
         hashobj = hash_algo()
         with open(file, "rb") as f:
@@ -175,7 +175,7 @@ def main():
         try:
             meta_file_exists = find_album_meta_json_file(path)
 
-            if meta_file_exists: #means that we are processing an album so process
+            if meta_file_exists:  # means that we are processing an album so process
                 for file in path.rglob("*"):
                     if file.is_file() and filter_fun(file):
                         file_name = file.name
@@ -185,7 +185,8 @@ def main():
                                 if full_hash in files_by_full_hash:
                                     full_hash_files = files_by_full_hash[full_hash]
                                     if len(full_hash_files) != 1:
-                                        print("full_hash_files list should only be one after duplication removal, bad state")
+                                        print(
+                                            "full_hash_files list should only be one after duplication removal, bad state")
                                         exit()
                                     else:
 
@@ -196,7 +197,7 @@ def main():
                             except:
                                 pass
 
-                        #check rename map in case there was an overlap namechange
+                        # check rename map in case there was an overlap namechange
 
                         if str(file) in rename_map:
                             file_name = rename_map[str(file)].name
@@ -204,7 +205,6 @@ def main():
                         album_mmap[file.parent.name].append(file_name)
         except:
             pass
-            
 
     # PART 3: removing duplicates
 
@@ -270,11 +270,11 @@ def main():
         # and remove all the other duplicates
         for files in files_by_full_hash.values():
             if len(files) < 2:
-                continue # this file size is unique, no need to spend cpu cycles on it
+                continue  # this file size is unique, no need to spend cpu cycles on it
 
             s_removed_duplicates_count += len(files) - 1
             for file in files:
-            #TODO reconsider which dup we delete these now that we're searching globally?
+                # TODO reconsider which dup we delete these now that we're searching globally?
                 if len(files) > 1:
                     file.unlink()
                     files.remove(file)
@@ -284,7 +284,7 @@ def main():
 
     # Returns json dict
     def find_json_for_file(file: Path):
-        potential_json = file.with_name(file.name + '.json') 
+        potential_json = file.with_name(file.name + '.json')
         if potential_json.is_file():
             try:
                 with open(potential_json, 'r') as f:
@@ -305,7 +305,8 @@ def main():
                         dict = _json.load(f)
                         if "date" in dict["albumData"]:
                             if "timestamp" in dict["albumData"]["date"]:
-                                return _datetime.fromtimestamp(int(dict["albumData"]["date"]["timestamp"])).strftime('%Y:%m:%d %H:%M:%S')
+                                return _datetime.fromtimestamp(int(dict["albumData"]["date"]["timestamp"])).strftime(
+                                    '%Y:%m:%d %H:%M:%S')
                 except:
                     pass
         except:
@@ -331,15 +332,16 @@ def main():
 
         return None
 
-
-
     def set_creation_date_from_str(file: Path, str_datetime):
         try:
             # Turns out exif can have different formats - YYYY:MM:DD, YYYY/..., YYYY-... etc
             # God wish that americans won't have something like MM-DD-YYYY
             # The replace ': ' to ':0' fixes issues when it reads the string as 2006:11:09 10:54: 1.
             # It replaces the extra whitespace with a 0 for proper parsing
-            str_datetime = str_datetime.replace('-', ':').replace('/', ':').replace('.', ':').replace('\\', ':').replace(': ', ':0')[:19]
+            str_datetime = str_datetime.replace('-', ':').replace('/', ':').replace('.', ':').replace('\\',
+                                                                                                      ':').replace(': ',
+                                                                                                                   ':0')[
+                           :19]
             timestamp = _datetime.strptime(
                 str_datetime,
                 '%Y:%m:%d %H:%M:%S'
@@ -522,7 +524,7 @@ def main():
 
         print('Last chance, coping folder meta as date...')
         date = get_date_from_folder_meta(file.parent)
-        if date: 
+        if date:
             set_file_exif_date(file, date)
             set_creation_date_from_str(file, date)
 

--- a/google_photos_takeout_helper/__main__.py
+++ b/google_photos_takeout_helper/__main__.py
@@ -12,6 +12,8 @@ def main():
     import piexif as _piexif
     from fractions import Fraction  # piexif requires some values to be stored as rationals
     import math
+    if _os.name == 'nt':
+        import win32_setctime as _windoza_setctime
 
     parser = _argparse.ArgumentParser(
         prog='Photos takeout helper',
@@ -349,6 +351,8 @@ def main():
                 '%Y:%m:%d %H:%M:%S'
             ).timestamp()
             _os.utime(file, (timestamp, timestamp))
+            if _os.name == 'nt':
+                _windoza_setctime.setctime()
         except Exception as e:
             print('Error setting creation date from string:')
             print(e)

--- a/google_photos_takeout_helper/__main__.py
+++ b/google_photos_takeout_helper/__main__.py
@@ -38,13 +38,6 @@ def main():
         help='Output folders which in all photos will be placed in'
     )
     parser.add_argument(
-        '--keep-duplicates',
-        action='store_true',
-        help="Don't remove duplicates. Disclaimer: "
-             "duplicates will have trouble to find correct creation date, "
-             "and it may not be accurate"
-    )
-    parser.add_argument(
         '--skip-extras',
         action='store_true',
         help='EXPERIMENTAL: Skips the extra photos like photos that end in "edited" or "EFFECTS".'
@@ -55,25 +48,16 @@ def main():
         help='EXPERIMENTAL: Skips the extra photos like photos like pic(1). Also includes --skip-extras.'
     )
     parser.add_argument(
-        '--dont-fix',
-        action='store_true',
-        help="Don't try to fix Dates. I don't know why would you not want to do that, but ok"
-    )
-    parser.add_argument(
-        '--dont-copy',
-        action='store_true',
-        help="Don't copy files to target folder. I don't know why would you not want to do that, but ok"
-    )
-    parser.add_argument(
         "--divide-to-dates",
         action='store_true',
         help="Create folders and subfolders based on the date the photos were taken"
              "If you use the --dont-copy flag, or the --dont-fix flag, this is useless"
     )
     parser.add_argument(
-        '--no-albums',
-        action='store_true',
-        help="Don't do anything about the albums"
+        '--albums',
+        type=str,
+        help="EXPERIMENTAL, MAY NOT WORK FOR EVERYONE: What kind of 'albums solution' you would like:\n"
+             "'json' - written in a json file\n"
     )
     args = parser.parse_args()
 
@@ -580,16 +564,15 @@ def main():
         s_copied_files += 1
         return True
 
-    if not args.dont_fix:
-        print('=====================')
-        print('Fixing files metadata and creation dates...')
-        print('=====================')
-        for_all_files_recursive(
-            dir=PHOTOS_DIR,
-            file_function=fix_metadata,
-            filter_fun=lambda f: (is_photo(f) or is_video(f))
-        )
-    if not args.dont_fix and not args.dont_copy and args.divide_to_dates:
+    print('=====================')
+    print('Fixing files metadata and creation dates...')
+    print('=====================')
+    for_all_files_recursive(
+        dir=PHOTOS_DIR,
+        file_function=fix_metadata,
+        filter_fun=lambda f: (is_photo(f) or is_video(f))
+    )
+    if args.divide_to_dates:
         print('=====================')
         print('Creating subfolders and dividing files based on date...')
         print('=====================')
@@ -598,7 +581,7 @@ def main():
             file_function=copy_to_target_and_divide,
             filter_fun=lambda f: (is_photo(f) or is_video(f))
         )
-    elif not args.dont_copy:
+    else:
         print('=====================')
         print('Coping all files to one folder...')
         print('(If you want, you can get them organized in folders based on year and month.'
@@ -609,27 +592,28 @@ def main():
             file_function=copy_to_target,
             filter_fun=lambda f: (is_photo(f) or is_video(f))
         )
-    if not args.keep_duplicates:
-        print('=====================')
-        print('Removing duplicates...')
-        print('=====================')
-        remove_duplicates(
-            dir=FIXED_DIR
-        )
-    if not args.no_albums:
-        print('=====================')
-        print('Populate albums...')
-        print('=====================')
-        for_all_files_recursive(
-            dir=PHOTOS_DIR,
-            folder_function=populate_album_map
-        )
-
-        with open(PHOTOS_DIR / 'albums.json', 'w') as outfile:
-            _json.dump(album_mmap, outfile)
+    print('=====================')
+    print('Removing duplicates...')
+    print('=====================')
+    remove_duplicates(
+        dir=FIXED_DIR
+    )
+    if args.albums is not None:
+        if args.albums.lower() == 'json':
+            print('=====================')
+            print('Populate json file with albums...')
+            print('=====================')
+            for_all_files_recursive(
+                dir=PHOTOS_DIR,
+                folder_function=populate_album_map
+            )
+            file = PHOTOS_DIR / 'albums.json'
+            with open(file, 'w') as outfile:
+                _json.dump(album_mmap, outfile)
+            print(str(file))
 
     print()
-    print('DONE! FREEDOM!')
+    print('DONE! FREEEEEDOOOOM!!!')
     print()
     print("Final statistics:")
     print(f"Files copied to target folder: {s_copied_files}")

--- a/google_photos_takeout_helper/__main__.py
+++ b/google_photos_takeout_helper/__main__.py
@@ -343,10 +343,7 @@ def main():
             # God wish that americans won't have something like MM-DD-YYYY
             # The replace ': ' to ':0' fixes issues when it reads the string as 2006:11:09 10:54: 1.
             # It replaces the extra whitespace with a 0 for proper parsing
-            str_datetime = str_datetime.replace('-', ':').replace('/', ':').replace('.', ':').replace('\\',
-                                                                                                      ':').replace(': ',
-                                                                                                                   ':0')[
-                           :19]
+            str_datetime = str_datetime.replace('-', ':').replace('/', ':').replace('.', ':').replace('\\', ':').replace(': ', ':0')[:19]
             timestamp = _datetime.strptime(
                 str_datetime,
                 '%Y:%m:%d %H:%M:%S'

--- a/google_photos_takeout_helper/__main__.py
+++ b/google_photos_takeout_helper/__main__.py
@@ -68,6 +68,11 @@ def main():
         help="Create folders and subfolders based on the date the photos were taken"
              "If you use the --dont-copy flag, or the --dont-fix flag, this is useless"
     )
+    parser.add_argument(
+        '--no-albums',
+        action='store_true',
+        help="Don't do anything about the albums"
+    )
     args = parser.parse_args()
 
     print('Heeeere we go!')
@@ -605,16 +610,17 @@ def main():
             dir=FIXED_DIR
         )
 
-    print('=====================')
-    print('Populate albums...')
-    print('=====================')
-    for_all_files_recursive(
-        dir=PHOTOS_DIR,
-        folder_function=populate_album_map
-    )
+    if not args.no_albums:
+        print('=====================')
+        print('Populate albums...')
+        print('=====================')
+        for_all_files_recursive(
+            dir=PHOTOS_DIR,
+            folder_function=populate_album_map
+        )
 
-    with open(str(FIXED_DIR) + '/albums.json', 'w+') as outfile:
-        _json.dump(album_mmap, outfile)
+        with open(PHOTOS_DIR / 'albums.json', 'w') as outfile:
+            _json.dump(album_mmap, outfile)
 
     print()
     print('DONE! FREEDOM!')

--- a/google_photos_takeout_helper/__main__.py
+++ b/google_photos_takeout_helper/__main__.py
@@ -402,6 +402,8 @@ def main():
             int(json['photoTakenTime']['timestamp'])
         ).strftime('%Y:%m:%d %H:%M:%S')
 
+    # ========= THIS IS ALL GPS STUFF =========
+
     def change_to_rational(number):
         """convert a number to rantional
         Keyword arguments: number
@@ -499,6 +501,8 @@ def main():
             print("Couldn't insert geo exif!")
             # local variable 'new_value' referenced before assignment means that one of the GPS values is incorrect
             print(e)
+
+    # ============ END OF GPS STUFF ============
 
     # Fixes ALL metadata, takes just file and dir and figures it out
     def fix_metadata(file: Path):
@@ -610,7 +614,6 @@ def main():
         remove_duplicates(
             dir=FIXED_DIR
         )
-
     if not args.no_albums:
         print('=====================')
         print('Populate albums...')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 piexif==1.1.3
+win32-setctime==1.0.3


### PR DESCRIPTION
Fixes: #10 and #22 and #30

This is still in draft for now just to get my current thoughts/progress out there so we can start discussions. Testing hasn't been done on a big takeout folder only a smaller subset.

Changes/Method:

 - I've updated duplication to happen after exif fix phase and file moving phase. 
 - Duplication now scans globally vs per date/album folders.
 - You no longer have to remove album folders.
 - Album folders are scanned as well in case photos that don't exist in date folders are there.
 - Once all files are in the output folder, we scan that location for duplicates.
 - Once the duplicates are removed in the output folder, album folders are scanned once again and matched with the file that exists in the output folder already if it is a duplicate. (This part still doesn't check for duplicates yet i'm still thinking through this part).
 - albums are currently going to be exported via a json file. This will be easy to update to any other variations once this code is reviewed, tested an in place.