### PR TITLE
Add 'NaN' string handling in altitude

### DIFF
--- a/google_photos_takeout_helper/__main__.py
+++ b/google_photos_takeout_helper/__main__.py
@@ -467,7 +467,7 @@ def main():
                 _piexif.GPSIFD.GPSLongitude: degToDmsRational(longitude)
             })
 
-        if altitude != 0:
+        if not isinstance(altitude, str) and altitude != 0:
             gps_ifd.update({
                 _piexif.GPSIFD.GPSAltitudeRef: 1,
                 _piexif.GPSIFD.GPSAltitude: change_to_rational(round(altitude))


### PR DESCRIPTION
I found some images with a sting containing 'NaN' for the altitude value so I added a check for this case. 