### PR TITLE
Remove non-existing flags

### DIFF
--- a/google_photos_takeout_helper/__main__.py
+++ b/google_photos_takeout_helper/__main__.py
@@ -51,7 +51,6 @@ def main():
         "--divide-to-dates",
         action='store_true',
         help="Create folders and subfolders based on the date the photos were taken"
-             "If you use the --dont-copy flag, or the --dont-fix flag, this is useless"
     )
     parser.add_argument(
         '--albums',


### PR DESCRIPTION
Hi, this PR removes help referencing old flags that do not exist any more:

- `--dont-copy`
- `--dont-fix`