### PR TITLE
Remember that album data is not available

### DIFF
--- a/google_photos_takeout_helper/__main__.py
+++ b/google_photos_takeout_helper/__main__.py
@@ -5,6 +5,7 @@ def main():
     import re as _re
     import shutil as _shutil
     import hashlib as _hashlib
+    import functools as _functools
     from collections import defaultdict as  _defaultdict
     from datetime import datetime as _datetime
     from pathlib import Path as Path
@@ -87,8 +88,6 @@ def main():
 
     # holds all the renamed files that clashed from their
     rename_map = dict()
-
-    meta_file_memo = dict()
 
     _all_jsons_dict = _defaultdict(dict)
 
@@ -326,19 +325,14 @@ def main():
 
         return None
 
+    @_functools.lru_cache(maxsize=None)
     def find_album_meta_json_file(dir: Path):
-        if str(dir) in meta_file_memo:
-            return meta_file_memo[str(dir)]
-
         for file in dir.rglob("*.json"):
             try:
                 with open(str(file), 'r') as f:
                     dict = _json.load(f)
                     if "albumData" in dict:
-                        meta_file_memo[str(dir)] = file
                         return file
-                    else:
-                        meta_file_memo[str(dir)] = None
             except Exception as e:
                 print(e)
                 print(f"find_album_meta_json_file - Error opening file: {file}")

--- a/google_photos_takeout_helper/__main__.py
+++ b/google_photos_takeout_helper/__main__.py
@@ -337,6 +337,8 @@ def main():
                     if "albumData" in dict:
                         meta_file_memo[str(dir)] = file
                         return file
+                    else:
+                        meta_file_memo[str(dir)] = None
             except Exception as e:
                 print(e)
                 print(f"find_album_meta_json_file - Error opening file: {file}")


### PR DESCRIPTION
This PR adds the option of remembering that the JSON from an album was not found.

When trying to obtain the date of a file we often call `get_date_from_folder_meta()` which calls `find_album_meta_json_file()` if we remember that there's no album we can avoid looking through all the `*.json` files again and just do it once per folder.