### PR TITLE
Dockerfile for running the helper in a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,5 @@ COPY tests  /usr/src/google_photos_takeout_helper/google_photos_takeout_helper/t
 ENV PYTHONPATH=.
 RUN ls -l
 RUN python3 setup.py install
-ENTRYPOINT [ "google-photos-takeout-helper" ]
+VOLUME [ "/input", "/output" ]
+ENTRYPOINT [ "google-photos-takeout-helper", "-i", "/input", "-o", "/output", "--divide-to-dates"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python
+RUN mkdir /usr/src/google_photos_takeout_helper
+WORKDIR /usr/src/google_photos_takeout_helper
+COPY LICENSE README.md requirements.txt setup.py /usr/src/google_photos_takeout_helper/
+COPY google_photos_takeout_helper  /usr/src/google_photos_takeout_helper/google_photos_takeout_helper
+COPY scripts /usr/src/google_photos_takeout_helper/google_photos_takeout_helper/scripts
+COPY tests  /usr/src/google_photos_takeout_helper/google_photos_takeout_helper/tests
+ENV PYTHONPATH=.
+RUN ls -l
+RUN python3 setup.py install
+ENTRYPOINT [ "google_photos_takeout_helper" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ COPY tests  /usr/src/google_photos_takeout_helper/google_photos_takeout_helper/t
 ENV PYTHONPATH=.
 RUN ls -l
 RUN python3 setup.py install
-ENTRYPOINT [ "google_photos_takeout_helper" ]
+ENTRYPOINT [ "google-photos-takeout-helper" ]


### PR DESCRIPTION
This Dockerfile contains everything you need to run the helper in a container. You need to link the two volumes (input and output) to the directories you want and everything else is done in the container. The base image contains all dependencies. I've been running this in Synology using their Docker engine. I can include a step-by-step tutorial if this is something that you want to include. I've already built the image on docker hub if anyone wants to experiment with it.

https://hub.docker.com/repository/docker/vukasin/googlephotostakeouthelper