### PR TITLE
Add support for photos edited in Dutch / NL locale

### DIFF
--- a/google_photos_takeout_helper/__main__.py
+++ b/google_photos_takeout_helper/__main__.py
@@ -119,6 +119,7 @@ def main():
         '-edited', '-effects', '-smile', '-mix',  # EN/US
         '-edytowane',  # PL
         '-bearbeitet', # DE
+        '-bewerkt',    # NL
         # Add more "edited" flags in more languages if you want. They need to be lowercase.
     ]
 


### PR DESCRIPTION
Adds support so that the Google Photos Takeout Helper can detect edited copies for Dutch users