### PR TITLE
added 'edited' flag for Japanese language

### DIFF
--- a/google_photos_takeout_helper/__main__.py
+++ b/google_photos_takeout_helper/__main__.py
@@ -120,6 +120,7 @@ def main():
         '-edytowane',  # PL
         '-bearbeitet', # DE
         '-bewerkt',    # NL
+        '-編集済み',    # JA
         # Add more "edited" flags in more languages if you want. They need to be lowercase.
     ]
 


### PR DESCRIPTION
Adds support so that the Google Photos Takeout Helper can detect edited copies for Japanese users.