### PR TITLE
Add iOS Live Photo support and another format for guess_extractor

### DIFF
--- a/bin/gpth.dart
+++ b/bin/gpth.dart
@@ -11,6 +11,7 @@ import 'package:gpth/media.dart';
 import 'package:gpth/moving.dart';
 import 'package:gpth/utils.dart';
 import 'package:path/path.dart' as p;
+import 'package:gpth/date_extractors/heic_video_extractor.dart';
 
 const helpText = """GooglePhotosTakeoutHelper v$version - The Dart successor
 
@@ -125,6 +126,7 @@ void main(List<String> arguments) async {
     jsonExtractor,
     exifExtractor,
     if (args['guess-from-name']) guessExtractor,
+    heicVideoExtractor,
     // this is potentially *dangerous* - see:
     // https://github.com/TheLastGimbus/GooglePhotosTakeoutHelper/issues/175
     (f) => jsonExtractor(f, tryhard: true),

--- a/lib/date_extractors/guess_extractor.dart
+++ b/lib/date_extractors/guess_extractor.dart
@@ -43,6 +43,12 @@ final _commonDatetimePatterns = [
         r'(?<date>(20|19|18)\d{2}_(01|02|03|04|05|06|07|08|09|10|11|12)_[0-3]\d_\d{2}_\d{2}_\d{2})'),
     'YYYY_MM_DD_hh_mm_ss',
   ],
+  // example: 20190620_184109.jpg
+  [
+    RegExp(
+        r'(20|19|18)\d{2}(01|02|03|04|05|06|07|08|09|10|11|12)[0-3]\d_\d{6}'),
+    'YYYYMMDD_hhmmss'
+  ]
 ];
 
 /// Guesses DateTime from [file]s name

--- a/lib/date_extractors/heic_video_extractor.dart
+++ b/lib/date_extractors/heic_video_extractor.dart
@@ -1,0 +1,44 @@
+import 'dart:io';
+import 'package:gpth/date_extractors/json_extractor.dart';
+import "package:path/path.dart" as p;
+
+/// Finds corresponding json file with info and gets 'photoTakenTime' from it
+Future<DateTime?> heicVideoExtractor(File file, {bool tryhard = false}) async {
+  final fileNameWithoutExtension = p.basenameWithoutExtension(file.path);
+
+  if (fileNameWithoutExtension.startsWith("IMG") &&
+      p.extension(file.path).toLowerCase() == ".mp4") {
+    final String parentPath = file.parent.path;
+    // Is a valid iOS Live Photo video
+    return tryGetDateTimeFromPossibleFileExtensions(
+        parentPath, fileNameWithoutExtension);
+  }
+
+  return null;
+}
+
+Future<DateTime?> tryGetDateTimeFromPossibleFileExtensions(
+    String parentPath, String fileNameWithoutExtension,
+    {bool tryhard = false}) async {
+  final possibleFileExtensions = <String>[
+    "HEIC",
+    "heic",
+    "JPG",
+    "jpg",
+    "JPEG",
+    "jpeg"
+  ];
+
+  for (final fileExtension in possibleFileExtensions) {
+    final String possiblePhotoPath =
+        p.join(parentPath, "$fileNameWithoutExtension.$fileExtension");
+    final result =
+        await jsonExtractor(File(possiblePhotoPath), tryhard: tryhard);
+
+    if (result != null) {
+      return result;
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
First of all, great tool! It has made my process of organising the Google Photos export so much nicer for when I upload the backup to S3.

I have tested the changes locally and it was able to add the EXIF date data to the video files successfully.