### PR TITLE
Fix extra files not being recognized on MacOS

### DIFF
--- a/lib/date_extractors/json_extractor.dart
+++ b/lib/date_extractors/json_extractor.dart
@@ -5,6 +5,7 @@ import 'package:collection/collection.dart';
 import 'package:gpth/extras.dart' as extras;
 import 'package:gpth/utils.dart';
 import 'package:path/path.dart' as p;
+import 'package:unorm_dart/unorm_dart.dart' as unorm;
 
 /// Finds corresponding json file with info and gets 'photoTakenTime' from it
 Future<DateTime?> jsonExtractor(File file, {bool tryhard = false}) async {
@@ -59,6 +60,9 @@ String _removeDigit(String filename) =>
 /// This removes only strings defined in [extraFormats] list from `extras.dart`,
 /// so it's pretty safe
 String _removeExtra(String filename) {
+  // MacOS uses NFD that doesn't work with our accents 🙃🙃
+  // https://github.com/TheLastGimbus/GooglePhotosTakeoutHelper/pull/247
+  filename = unorm.nfc(filename);
   for (final extra in extras.extraFormats) {
     if (filename.contains(extra)) {
       return filename.replaceLast(extra, '');
@@ -77,6 +81,9 @@ String _removeExtra(String filename) {
 /// ```
 /// so it's *kinda* safe
 String _removeExtraRegex(String filename) {
+  // MacOS uses NFD that doesn't work with our accents 🙃🙃
+  // https://github.com/TheLastGimbus/GooglePhotosTakeoutHelper/pull/247
+  filename = unorm.nfc(filename);
   // include all characters, also with accents
   final matches = RegExp(r'(?<extra>-[A-Za-zÀ-ÖØ-öø-ÿ]+(\(\d\))?)\.\w+$')
       .allMatches(filename);

--- a/lib/extras.dart
+++ b/lib/extras.dart
@@ -1,4 +1,5 @@
 import 'package:path/path.dart' as p;
+import 'package:unorm_dart/unorm_dart.dart' as unorm;
 
 import 'media.dart';
 
@@ -34,7 +35,9 @@ int removeExtras(List<Media> media) {
   for (final m in copy) {
     final name = p.withoutExtension(p.basename(m.firstFile.path)).toLowerCase();
     for (final extra in extraFormats) {
-      if (name.endsWith(extra)) {
+      // MacOS uses NFD that doesn't work with our accents 🙃🙃
+      // https://github.com/TheLastGimbus/GooglePhotosTakeoutHelper/pull/247
+      if (unorm.nfc(name).endsWith(extra)) {
         media.remove(m);
         count++;
         break;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -417,6 +417,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  unorm_dart:
+    dependency: "direct main"
+    description:
+      name: unorm_dart
+      sha256: "5b35bff83fce4d76467641438f9e867dc9bcfdb8c1694854f230579d68cd8f4b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   #      url: https://github.com/TheLastGimbus/archive.git
   #      ref: fix-windoza-extract-errors
   proper_filesize: ^0.0.2
+  unorm_dart: ^0.2.0
 
 dev_dependencies:
   lints: ^2.1.1


### PR DESCRIPTION
# A bit of comment for future generations:

As @palijn nicely summarised it - "Linux file systems use NFC where MAC FS choose NFD" - which, said NFD, doesn't `==` accents and other unicode stuff with our extras collection

This caused #204 (we didn't have separate `-modife` then but I added regex option that still didn't work), then #243, and probably few other issues

I really thought we had all of the "encoding something something" nightmare resolved ages ago -_-

So, merging this closes #243 :)