### PR TITLE
Ignore dotfiles

### DIFF
--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -42,6 +42,7 @@ extension X on Iterable<FileSystemEntity> {
 extension Y on Stream<FileSystemEntity> {
   /// Easy extension allowing you to filter for files that are photo or video
   Stream<File> wherePhotoVideo() => whereType<File>().where((e) {
+        if (p.basename(e.path).startsWith('.')) return false;
         final mime = lookupMimeType(e.path) ?? "";
         return mime.startsWith('image/') ||
             mime.startsWith('video/') ||


### PR DESCRIPTION
Fixes #203. It just doesn't consider any file that begins with a dot as a valid media file.