### PR TITLE
Allow cross-drive moving

### DIFF
--- a/lib/moving.dart
+++ b/lib/moving.dart
@@ -131,18 +131,16 @@ Stream<int> moveFiles(
       moveFile() async {
         final freeFile = findNotExistingName(
             File(p.join(folder.path, p.basename(file.value.path))));
-        try {
-          return copy
-              ? await file.value.copy(freeFile.path)
-              : await file.value.rename(freeFile.path);
-        } on FileSystemException {
-          print(
-            "Uh-uh, it looks like you selected other output drive than\n"
-            "input one - gpth can't move files between them. But, you don't have\n"
-            "to do this! Gpth *moves* files, so this doesn't take any extra space!\n"
-            "Please run again and select different output location <3",
-          );
-          quit(1);
+        if (copy) {
+          return await file.value.copy(freeFile.path);
+        } else {
+          try {
+            return await file.value.rename(freeFile.path);
+          } on FileSystemException {
+            var temp = await file.value.copy(freeFile.path);
+            await file.value.delete();
+            return temp;
+          }
         }
       }
 


### PR DESCRIPTION
Fixes #251. Dart recommends copying and then deleting the original file; it's not ideal but it's the only way. Only tries to do this when renaming fails. It uses more space but since it's on a different drive it's not an issue, and it's only temporary.