### PR TITLE
Fix Incorrect Default Value for --albums Option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ In that case:
      cd Downloads  # Most probably
      # run it, selecting input and output folders with options like this:
      # (you can try to drag and drop them)
-     gpth.exe --input "Downloads\you\input\folder" --output "C:\some\other\location" --albums "shortcuts"
+     gpth.exe --input "Downloads\you\input\folder" --output "C:\some\other\location" --albums "shortcut"
      # select which album solution you like - see --help for all of them
      # remember to use "" !
      ```
@@ -95,7 +95,7 @@ In that case:
      chmod +x gpth  # add execute permission
      # tell MacOS Gatekeeper to not worry
      xattr -r -d com.apple.quarantine gpth-macos
-     ./gpth --input "/some/input/folder" --output "other/output/folder" --albums "shortcuts"
+     ./gpth --input "/some/input/folder" --output "other/output/folder" --albums "shortcut"
      # select which album solution you like - see --help for all of them
      ```
 


### PR DESCRIPTION
While reviewing the README documentation, I identified an inconsistency with the default value provided for the `--albums` option. The documentation erroneously listed `shortcuts` as a valid value. However, based on the `--help` output and the actual behavior of the software, the correct default value is `shortcut`.

**Changes Made:**

- Corrected the default value for the `--albums` option in the README from `shortcuts` to `shortcut`.

**Rationale:**

This correction ensures that users are provided with accurate information regarding the usage of the `--albums` option. The correct default value, `shortcut`, reflects the software's functionality more accurately and prevents potential confusion, ensuring a smoother user experience.

**Impact:**

This change is confined to the README documentation and does not affect the software's functionality. It is aimed at improving the accuracy of the documentation for better user guidance.

**Help output:**

```
# ./gpth-linux --help
GooglePhotosTakeoutHelper v3.4.3 - The Dart successor

gpth is ment to help you with exporting your photos from Google Photos.

First, go to https://takeout.google.com/ , deselect all and select only Photos.
When ready, download all .zips, and extract them into *one* folder.
(Auto-extracting works only in interactive mode)

Then, run: gpth --input "folder/with/all/takeouts" --output "your/output/folder"
...and gpth will parse and organize all photos into one big chronological folder

-h, --help
    --fix                         Folder with any photos to fix dates. This skips whole "GoogleTakeout" procedure.It is here because gpth has some cool heuristics to determine date of a photo, and this can be handy in many situations :)
    --[no-]interactive            Use interactive mode. Type this in case auto-detection fails, or you *really* want to combine advanced options with prompts
-i, --input                       Input folder with *all* takeouts *extracted*.
-o, --output                      Output folder where all photos will land
    --albums                      What to do about albums?

          [duplicate-copy]        Album folders with photos copied into them. This will work across all systems, but may take wayyy more space!!
          [json]                  Put ALL photos (including Archive and Trash) in one folder and make a .json file with info about albums. Use if you're a programmer, or just want to get everything, ignoring lack of year-folders etc.
          [nothing]               Just ignore them and put year-photos into one folder. WARNING: This ignores Archive/Trash !!!
          [shortcut] (default)    [Recommended] Album folders with shortcuts/symlinks to original photos. Recommended as it will take the least space, but may not be portable when moving across systems/computes/phones etc

    --[no-]divide-to-dates        Divide output to folders by year/month
    --[no-]skip-extras            Skip extra images (like -edited etc)
    --[no-]guess-from-name        Try to guess file dates from their names
                                  (defaults to on)
    --[no-]copy                   Copy files instead of moving them.
                                  This is usually slower, and uses extra space, but doesn't break your input folder
```