### PR TITLE
utils: Read file header if mime type can't be detected

### DIFF
--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -26,8 +26,18 @@ Never quit([int code = 1]) {
   exit(code);
 }
 
+String getMime(File e) {
+  var mime = lookupMimeType(e.path);
+  if (mime != null)
+    return mime;
+  RandomAccessFile rafile = e.openSync();
+  final header = rafile.readSync(defaultMagicNumbersMaxLength);
+  rafile.closeSync();
+  return lookupMimeType(e.path, headerBytes: header) ?? "";
+}
+
 bool isMedia(File e) {
-  final mime = lookupMimeType(e.path) ?? "";
+  final mime = getMime(e);
   return mime.startsWith('image/') ||
     mime.startsWith('video/') ||
     // https://github.com/TheLastGimbus/GooglePhotosTakeoutHelper/issues/223

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -26,30 +26,24 @@ Never quit([int code = 1]) {
   exit(code);
 }
 
+bool isMedia(File e) {
+  final mime = lookupMimeType(e.path) ?? "";
+  return mime.startsWith('image/') ||
+    mime.startsWith('video/') ||
+    // https://github.com/TheLastGimbus/GooglePhotosTakeoutHelper/issues/223
+    // https://github.com/dart-lang/mime/issues/102
+    // 🙃🙃
+    mime == 'model/vnd.mts';
+}
+
 extension X on Iterable<FileSystemEntity> {
   /// Easy extension allowing you to filter for files that are photo or video
-  Iterable<File> wherePhotoVideo() => whereType<File>().where((e) {
-        final mime = lookupMimeType(e.path) ?? "";
-        return mime.startsWith('image/') ||
-            mime.startsWith('video/') ||
-            // https://github.com/TheLastGimbus/GooglePhotosTakeoutHelper/issues/223
-            // https://github.com/dart-lang/mime/issues/102
-            // 🙃🙃
-            mime == 'model/vnd.mts';
-      });
+  Iterable<File> wherePhotoVideo() => whereType<File>().where(isMedia);
 }
 
 extension Y on Stream<FileSystemEntity> {
   /// Easy extension allowing you to filter for files that are photo or video
-  Stream<File> wherePhotoVideo() => whereType<File>().where((e) {
-        final mime = lookupMimeType(e.path) ?? "";
-        return mime.startsWith('image/') ||
-            mime.startsWith('video/') ||
-            // https://github.com/TheLastGimbus/GooglePhotosTakeoutHelper/issues/223
-            // https://github.com/dart-lang/mime/issues/102
-            // 🙃🙃
-            mime == 'model/vnd.mts';
-      });
+  Stream<File> wherePhotoVideo() => whereType<File>().where(isMedia);
 }
 
 extension Util on Stream {


### PR DESCRIPTION
If the mime type can't be detected using the extension alone, open the file and try again with a few bytes of header.

Allows for file type detection for `.MP` files that the Google Pixel phone generates.

Fixes #324.