### PR TITLE
Add Support for iPhone Raw and Live Photos

### DIFF
--- a/lib/extras.dart
+++ b/lib/extras.dart
@@ -27,6 +27,15 @@ const extraFormats = [
   // They need to be lowercase.
 ];
 
+
+const imageFormats = [
+  'jpg',
+  'jpeg',
+  'mp.jpg',
+  'dng',
+  'heic',
+];
+
 /// Removes any media that match any of "extra" formats
 /// Returns count of removed
 int removeExtras(List<Media> media) {

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -35,7 +35,10 @@ extension X on Iterable<FileSystemEntity> {
             // https://github.com/TheLastGimbus/GooglePhotosTakeoutHelper/issues/223
             // https://github.com/dart-lang/mime/issues/102
             // 🙃🙃
-            mime == 'model/vnd.mts';
+            mime == 'model/vnd.mts'||
+            // temporary support for Apple Raw image formats
+            p.extension(e.path).toLowerCase() == ".dng" ||
+            p.extension(e.path).toLowerCase() == ".cr2" ;
       });
 }
 
@@ -48,7 +51,10 @@ extension Y on Stream<FileSystemEntity> {
             // https://github.com/TheLastGimbus/GooglePhotosTakeoutHelper/issues/223
             // https://github.com/dart-lang/mime/issues/102
             // 🙃🙃
-            mime == 'model/vnd.mts';
+            mime == 'model/vnd.mts' ||
+            // temporary support for Apple Raw image formats
+            p.extension(e.path).toLowerCase() == ".dng"||
+            p.extension(e.path).toLowerCase() == ".cr2" ;
       });
 }
 


### PR DESCRIPTION
A known issue with Takeout is that for moving images (Live Photos) some devices - mainly iPhones - store this as two seperate files, one is an image and one is a video. Takeout will only produce a json for the image file leaving the video component without metadata. This code attempts to sync the video and image so that the video file can pull metadata from the image's json.

Also adds support for .DNG and .CR2 raw formats that are supported by the iPhone.

Fixes for issue #180 and #271. 