### PR TITLE
Handle edge case where image file was uploaded without an extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ What if you want to just have one folder with all photos, in chronological order
 
 This script does just that - it organizes and cleans up your Takeout for you 🧹😌
 
-It will take all of those folders, find all photos in them, set their and `file last modified` correctly, and put it in one big folder (or folders divided by a month) 🗄
+It will take all of those folders, find all photos in them, set their `file last modified` correctly, and put it in one big folder (or folders divided by a month) 🗄
 
 ## How to use:
 Since `v3.2.0`, `gpth` is interactive 🎉 - you don't need to type any complicated arguments - just get your takeout, run gpth, and follow prompted instructions 💃

--- a/lib/date_extractors/json_extractor.dart
+++ b/lib/date_extractors/json_extractor.dart
@@ -55,10 +55,10 @@ Future<File?> _jsonForFile(File file, {required bool tryhard}) async {
   return null;
 }
 
-// if the original file was uploaded without an extension there will be no
-// extension in the "title" of the json but the image in the filesystem will
-// have one that was automatically added, hence we need to ignore it when
-// searching for the json
+// if the originally file was uploaded without an extension, 
+// (for example, "20030616" (jpg but without ext))
+// it's json won't have the extension ("20030616.json"), but the image
+// itself (after google proccessed it) - will ("20030616.jpg" tadam)
 String _noExtension(String filename) =>
     p.basenameWithoutExtension(File(filename).path);
 

--- a/lib/date_extractors/json_extractor.dart
+++ b/lib/date_extractors/json_extractor.dart
@@ -40,6 +40,7 @@ Future<File?> _jsonForFile(File file, {required bool tryhard}) async {
     // test: combining this with _shortenName?? which way around?
     _bracketSwap,
     _removeExtra,
+    _noExtension,
     // use those two only with tryhard
     // look at https://github.com/TheLastGimbus/GooglePhotosTakeoutHelper/issues/175
     // thanks @denouche for reporting this!
@@ -53,6 +54,13 @@ Future<File?> _jsonForFile(File file, {required bool tryhard}) async {
   }
   return null;
 }
+
+// if the original file was uploaded without an extension there will be no
+// extension in the "title" of the json but the image in the filesystem will
+// have one that was automatically added, hence we need to ignore it when
+// searching for the json
+String _noExtension(String filename) =>
+    p.basenameWithoutExtension(File(filename).path);
 
 String _removeDigit(String filename) =>
     filename.replaceAll(RegExp(r'\(\d\)\.'), '.');

--- a/lib/grouping.dart
+++ b/lib/grouping.dart
@@ -36,7 +36,7 @@ extension Group on Iterable<Media> {
 
 /// Removes duplicate media from list of media
 ///
-/// This is ment to be used *early*, and it's aware of un-merged albums.
+/// This is meant to be used *early*, and it's aware of un-merged albums.
 /// Meaning, it will leave duplicated files if they have different
 /// [Media.albums] value
 ///


### PR DESCRIPTION
In my Google Photos Takeout I had some weird files where the json filename didn't include the extension of the image.
Example: `2013-08-22.json` for image `2013-08-22.png`.

This happened because the image was originally uploaded without an extension, which is underpinned by the fact that the json file says `"title": "2013-08-22"`.
Google Photos added the png extension (also have cases with jpg) automatically but didn't include this in the title field or json filename.

To handle such cases correctly we need to try to look for a json file while ignoring the filename.
