### PR TITLE
Remove json suffix "supplemental-metadata"

### DIFF
--- a/bin/gpth.dart
+++ b/bin/gpth.dart
@@ -61,6 +61,12 @@ void main(List<String> arguments) async {
       help: "Copy files instead of moving them.\n"
           "This is usually slower, and uses extra space, "
           "but doesn't break your input folder",
+    )
+    ..addFlag(
+      'modify-json', 
+      help: 'Delete the "supplemental-metadata" suffix from '
+      '.json files to ensure that script works correctly',
+      defaultsTo: true,
     );
   final args = <String, dynamic>{};
   try {
@@ -209,7 +215,7 @@ void main(List<String> arguments) async {
   }
   await output.create(recursive: true);
 
-  if (args['modify-json'].toString() == "0") {
+  if (args['modify-json']) {
     print('Fixing JSON files. Removing suffix (this may take some time)...');
     await renameIncorrectJsonFiles(input);
   }

--- a/bin/gpth.dart
+++ b/bin/gpth.dart
@@ -107,6 +107,8 @@ void main(List<String> arguments) async {
     print('');
     args['divide-to-dates'] = await interactive.askDivideDates();
     print('');
+    args['modify-json'] = await interactive.askModifyJson();
+    print('');
     args['albums'] = await interactive.askAlbums();
     print('');
 
@@ -206,6 +208,12 @@ void main(List<String> arguments) async {
     }
   }
   await output.create(recursive: true);
+
+  if (args['modify-json'].toString() == "0") {
+    print('Fixin JSON files. Removing suffix (this may take some time) ...');
+    await renameIncorrectJsonFiles(input);
+  }
+
 
   /// ##################################################
 

--- a/bin/gpth.dart
+++ b/bin/gpth.dart
@@ -210,10 +210,9 @@ void main(List<String> arguments) async {
   await output.create(recursive: true);
 
   if (args['modify-json'].toString() == "0") {
-    print('Fixin JSON files. Removing suffix (this may take some time) ...');
+    print('Fixing JSON files. Removing suffix (this may take some time)...');
     await renameIncorrectJsonFiles(input);
   }
-
 
   /// ##################################################
 

--- a/lib/interactive.dart
+++ b/lib/interactive.dart
@@ -186,7 +186,7 @@ Future<bool> askDivideDates() async {
   }
 }
 
-Future<num> askModifyJson() async {
+Future<bool> askModifyJson() async {
   print(
       'Check if your .json files of your photos contains "supplemental-metadata" '
       'between the original extension and .json. If this suffix is present, '
@@ -201,10 +201,10 @@ Future<num> askModifyJson() async {
     case '1':
     case '':
       print('Will erease the suffix "supplemental-metadata"');
-      return 0;
+      return true;
     case '2':
       print('Will not erease the suffix');
-      return 1;
+      return false;
     default:
       error('Invalid answer - try again');
       return askModifyJson();

--- a/lib/interactive.dart
+++ b/lib/interactive.dart
@@ -186,6 +186,29 @@ Future<bool> askDivideDates() async {
   }
 }
 
+Future<num> askModifyJson() async {
+  print('Check if your .json files of your photos contains "supplemental-metadata" '
+      'between the original extension and .json. If this suffix is present, '
+      'the script will not detect the corresponding JSON file');
+  print('For example: myImageName.jpg.supplemental-metadata.json');
+  print('[1] (Erase suffix) - [Recommended] Yes, the photos have the suffix "supplemental-metadata"');
+  print('[2] (Dont Erease suffix) - No');
+  print('(Type a number or press enter for default):');
+  final answer = await askForInt();
+  switch (answer) {
+    case '1':
+    case '':
+      print('Will erease the suffix "supplemental-metadata"');
+      return 0;
+    case '2':
+      print('Will not erease the suffix');
+      return 1;
+    default:
+      error('Invalid answer - try again');
+      return askModifyJson();
+  }
+}
+
 Future<String> askAlbums() async {
   print('What should be done with albums?');
   var i = 0;

--- a/lib/interactive.dart
+++ b/lib/interactive.dart
@@ -187,11 +187,13 @@ Future<bool> askDivideDates() async {
 }
 
 Future<num> askModifyJson() async {
-  print('Check if your .json files of your photos contains "supplemental-metadata" '
+  print(
+      'Check if your .json files of your photos contains "supplemental-metadata" '
       'between the original extension and .json. If this suffix is present, '
       'the script will not detect the corresponding JSON file');
   print('For example: myImageName.jpg.supplemental-metadata.json');
-  print('[1] (Erase suffix) - [Recommended] Yes, the photos have the suffix "supplemental-metadata"');
+  print(
+      '[1] (Erase suffix) - [Recommended] Yes, the photos have the suffix "supplemental-metadata"');
   print('[2] (Dont Erease suffix) - No');
   print('(Type a number or press enter for default):');
   final answer = await askForInt();


### PR DESCRIPTION
Added an option to remove the "supplemental-metadata" and its variants ("supplem", "supplementa", etc) suffix from JSON to prevent issues with metadata before gpth run the copies/move functions. Fixes: https://github.com/TheLastGimbus/GooglePhotosTakeoutHelper/issues/353


