### PR TITLE
Reverse-shortcut option (Original in album, shortcuts in ALL_PHOTOS folder)

### DIFF
--- a/lib/interactive.dart
+++ b/lib/interactive.dart
@@ -32,6 +32,11 @@ const albumOptions = {
       "ignoring lack of year-folders etc.",
   'nothing': 'Just ignore them and put year-photos into one folder. '
       'WARNING: This ignores Archive/Trash !!!',
+  'reverse-shortcut': 'Album folders with ORIGINAL photos. "ALL_PHOTOS" folder '
+      'with shortcuts/symlinks to albums. If a photo is not in an album, '
+      'the original is saved. CAUTION: If a photo is in multiple albums, it will '
+      'be duplicated in the other albums, and the shortcuts/symlinks in '
+      '"ALL_PHOTOS" will point only to one album.',
 };
 
 /// Whether we are, indeed, running interactive (or not)

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -114,7 +114,7 @@ String filesize(int bytes) => ProperFilesize.generateHumanReadableFilesize(
     );
 
 int outputFileCount(List<Media> media, String albumOption) {
-  if (['shortcut', 'duplicate-copy'].contains(albumOption)) {
+  if (['shortcut', 'duplicate-copy', 'reverse-shortcut'].contains(albumOption)) {
     return media.fold(0, (prev, e) => prev + e.files.length);
   } else if (albumOption == 'json') {
     return media.length;


### PR DESCRIPTION
The original `shortcut` option creates shortcuts/symlinks in album folders and keeps the original in the ALL_PHOTOS folder. In my case, I needed to keep the original photo in my album folders and create a shortcut in the ALL_PHOTOS folder, as I felt that it was more organized that way.

This PR adds a new option `[4] reverse-shortcut`. Now, I can keep the original photo file in album folders and create a shortcut in the ALL_PHOTOS/years albums.

Limitations
- If a photo is in multiple albums, the original will be in all other albums (except ALL_PHOTOS/years albums).
- If a photo is in multiple albums, the shortcuts/symlinks in "ALL_PHOTOS" will point to only one of those albums.
