### PR TITLE
More extensions to move/copy (.MP .MV .DNG and .CR2) and option to transform Pixel Motion Photo to .mp4

### DIFF
--- a/bin/gpth.dart
+++ b/bin/gpth.dart
@@ -61,7 +61,10 @@ void main(List<String> arguments) async {
       help: "Copy files instead of moving them.\n"
           "This is usually slower, and uses extra space, "
           "but doesn't break your input folder",
-    );
+    )
+    ..addFlag(
+      'transform-pixel-mp', 
+      help: 'Transform Pixel .MP or .MV extensions to ".mp4"');
   final args = <String, dynamic>{};
   try {
     final res = parser.parse(arguments);
@@ -108,6 +111,8 @@ void main(List<String> arguments) async {
     args['divide-to-dates'] = await interactive.askDivideDates();
     print('');
     args['albums'] = await interactive.askAlbums();
+    print('');
+    args['transform-pixel-mp'] = await interactive.askTransformPixelMP();
     print('');
 
     // @Deprecated('Interactive unzipping is suspended for now!')
@@ -354,6 +359,15 @@ void main(List<String> arguments) async {
 
   print('Finding albums (this may take some time, dont worry :) ...');
   findAlbums(media);
+
+  // Change Pixel Motion Photos extension to .mp4 using a list of Medias.
+  // This is done after the dates of files have been defined, and before
+  // the files are moved to the output folder, to avoid shortcuts/symlinks problems
+  if (args['transform-pixel-mp']) {
+    print('Changing .MP or .MV extensions to .mp4 (this may take some time) ...');
+    await changeMPExtensions(media, ".mp4");
+  }
+  print('');
 
   /// #######################
 

--- a/lib/interactive.dart
+++ b/lib/interactive.dart
@@ -230,6 +230,28 @@ Future<bool> askForCleanOutput() async {
   }
 }
 
+Future<bool> askTransformPixelMP() async {
+  print('Pixel Motion Pictures are saved with the .MP or .MV '
+      'extensions. Do you want to change them to .mp4 '
+      'for better compatibility?');
+  print('[1] (default) - no, keep original extension');
+  print('[2] - yes, change extension to .mp4');
+  print('(Type 1 or 2 or press enter for default):');
+  final answer = await askForInt();
+  switch (answer) {
+    case '1':
+    case '':
+      print('Okay, will keep original extension');
+      return false;
+    case '2':
+      print('Okay, will change to mp4!');
+      return true;
+    default:
+      error('Invalid answer - try again');
+      return askTransformPixelMP();
+  }
+}
+
 /// Checks free space on disk and notifies user accordingly
 @Deprecated('Interactive unzipping is suspended for now!')
 Future<void> freeSpaceNotice(int required, Directory dir) async {

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -30,12 +30,14 @@ extension X on Iterable<FileSystemEntity> {
   /// Easy extension allowing you to filter for files that are photo or video
   Iterable<File> wherePhotoVideo() => whereType<File>().where((e) {
         final mime = lookupMimeType(e.path) ?? "";
+        final fileExtension = p.extension(e.path).toLowerCase();
         return mime.startsWith('image/') ||
             mime.startsWith('video/') ||
             // https://github.com/TheLastGimbus/GooglePhotosTakeoutHelper/issues/223
             // https://github.com/dart-lang/mime/issues/102
             // 🙃🙃
-            mime == 'model/vnd.mts';
+            mime == 'model/vnd.mts'||
+            _moreExtensions.contains(fileExtension);
       });
 }
 
@@ -43,14 +45,19 @@ extension Y on Stream<FileSystemEntity> {
   /// Easy extension allowing you to filter for files that are photo or video
   Stream<File> wherePhotoVideo() => whereType<File>().where((e) {
         final mime = lookupMimeType(e.path) ?? "";
+        final fileExtension = p.extension(e.path).toLowerCase();
         return mime.startsWith('image/') ||
             mime.startsWith('video/') ||
             // https://github.com/TheLastGimbus/GooglePhotosTakeoutHelper/issues/223
             // https://github.com/dart-lang/mime/issues/102
             // 🙃🙃
-            mime == 'model/vnd.mts';
+            mime == 'model/vnd.mts'||
+            _moreExtensions.contains(fileExtension);
       });
 }
+
+//Support raw formats (dng, cr2) and Pixel motion photos (mp, mv)
+const _moreExtensions = ['.mp', '.mv', '.dng', '.cr2'];
 
 extension Util on Stream {
   Stream<T> whereType<T>() => where((e) => e is T).cast<T>();


### PR DESCRIPTION
Added support for moving or copying files with the following extensions to the output folder: .MP, .MV, .DNG, and .CR2.

Added an interactive option to convert Pixel Motion Photo files (.MP or .MV) to .mp4.

Fixes: https://github.com/TheLastGimbus/GooglePhotosTakeoutHelper/issues/381 https://github.com/TheLastGimbus/GooglePhotosTakeoutHelper/issues/324  https://github.com/TheLastGimbus/GooglePhotosTakeoutHelper/issues/180  https://github.com/TheLastGimbus/GooglePhotosTakeoutHelper/issues/271

Limitations:
- It does not fix issues related to reading JSON files (if necessary) for Motion Photo files; however, if the dates are included in the file name (as with Pixel Motion Photos), the correct dates will be established.