### PR TITLE
Option to update creation time at the end of program - Windows only

### DIFF
--- a/bin/gpth.dart
+++ b/bin/gpth.dart
@@ -61,6 +61,12 @@ void main(List<String> arguments) async {
       help: "Copy files instead of moving them.\n"
           "This is usually slower, and uses extra space, "
           "but doesn't break your input folder",
+    )
+    ..addFlag(
+      'update-creation-time', 
+      help: "Set creation time equal to the last "
+      'modification date at the end of the program.'
+      'Only Windows supported'
     );
   final args = <String, dynamic>{};
   try {
@@ -109,6 +115,10 @@ void main(List<String> arguments) async {
     print('');
     args['albums'] = await interactive.askAlbums();
     print('');
+    if (Platform.isWindows){ //Only in windows is going to ask
+      args['update-creation-time'] = await interactive.askChangeCreationTime();
+      print('');
+    }
 
     // @Deprecated('Interactive unzipping is suspended for now!')
     // // calculate approx space required for everything
@@ -391,6 +401,12 @@ void main(List<String> arguments) async {
     print("Couldn't find date for $countPoop photos/videos :/");
   }
   print('');
+  if (args['update-creation-time']) {
+    print('Updating creation time of files to match their modified time in output folder ...');
+    await updateCreationTimeRecursively(output);
+    print('');
+    print('=' * barWidth);
+  }
   print(
     "Last thing - I've spent *a ton* of time on this script - \n"
     "if I saved your time and you want to say thanks, you can send me a tip:\n"

--- a/lib/interactive.dart
+++ b/lib/interactive.dart
@@ -230,6 +230,30 @@ Future<bool> askForCleanOutput() async {
   }
 }
 
+Future<bool> askChangeCreationTime() async {
+  print('This program fixes file "modified times". '
+      'Due to language limitations, creation times remain unchanged. '
+      'Would you like to run a separate script at the end to sync '
+      'creation times with modified times?'
+      '\nNote: ONLY ON WINDOWS');
+  print('[1] (Default) - No, don\'t update creation time');
+  print('[2] - Yes, update creation time to match modified time');
+  print('(Type 1 or 2, or press enter for default):');
+  final answer = await askForInt();
+  switch (answer) {
+    case '1':
+    case '':
+      print('Okay, will not change creation time');
+      return false;
+    case '2':
+      print('Okay, will update creation time at the end of the prorgam!');
+      return true;
+    default:
+      error('Invalid answer - try again');
+      return askChangeCreationTime();
+  }
+}
+
 /// Checks free space on disk and notifies user accordingly
 @Deprecated('Interactive unzipping is suspended for now!')
 Future<void> freeSpaceNotice(int required, Directory dir) async {


### PR DESCRIPTION
This PR adds an option called "update-creation-time" that currently works only on Windows. If the user opts to use this option, the program will **update the creation times of files in the output folder to match their last modified times at the end of the program** (after all files are in output folders). 

This option uses PowerShell commands combined with batch logic to avoid starting a new PowerShell process for every file (it currently ensures that the command does not exceed 32,000 characters, which is near the command-line limit). Thanks to this batch logic, it can update 50 or more files per PowerShell execution (instead of 1 file per PowerShell execution), allowing thousands of files to be updated very quickly.

This batch logic could also be applied to shortcut creation for Windows users in the future, because currently creating shortcuts (when `shortcut` option is selected) for large collections of images takes a long time, as it executes one PowerShell command per media file.

In the future it may be possible to add this option for macOS users, but the limitation is that users need to have Xcode installed.

It partially fixes #371