### PR TITLE
Windows: 10x faster shortcut creation and fixed emoji folder name issues (also fix broken shortcuts in Win)

### DIFF
--- a/lib/moving.dart
+++ b/lib/moving.dart
@@ -32,28 +32,34 @@ Future<File> createShortcut(Directory location, File target) async {
   // this must be relative to not break when user moves whole folder around:
   // https://github.com/TheLastGimbus/GooglePhotosTakeoutHelper/issues/232
   final targetRelativePath = p.relative(target.path, from: link.parent.path);
+  final targetPath = target.absolute.path;
   if (Platform.isWindows) {
-    final res = await Process.run(
-      'powershell.exe',
-      [
-        '-ExecutionPolicy',
-        'Bypass',
-        '-NoLogo',
-        '-NonInteractive',
-        '-NoProfile',
-        '-Command',
-        '\$ws = New-Object -ComObject WScript.Shell; '
-            '\$s = \$ws.CreateShortcut(\'${link.path}\'); '
-            '\$s.TargetPath = \'$targetRelativePath\'; '
-            '\$s.Save()',
-      ],
-    );
-    if (res.exitCode != 0) {
-      throw 'PowerShell doesnt work :( - '
-          'report that to @TheLastGimbus on GitHub:\n\n'
-          'https://github.com/TheLastGimbus/GooglePhotosTakeoutHelper/issues\n\n'
-          '...or try other album solution\n'
-          'sorry for inconvenience :(';
+    try {
+      createShortcutWin(link.path, targetPath);
+    }catch (e) {
+      final res = await Process.run(
+        'powershell.exe',
+        [
+          '-ExecutionPolicy',
+          'Bypass',
+          '-NoLogo',
+          '-NonInteractive',
+          '-NoProfile',
+          '-Command',
+          '\$ws = New-Object -ComObject WScript.Shell; '
+              '\$s = \$ws.CreateShortcut(\'${link.path}\'); '
+              '\$s.TargetPath = \'$targetPath\'; '
+              '\$s.Save()',
+        ],
+      );
+      if (res.exitCode != 0) {
+        throw 'PowerShell doesnt work :( - '
+            'report that to @TheLastGimbus on GitHub:\n\n'
+            'https://github.com/TheLastGimbus/GooglePhotosTakeoutHelper/issues\n\n'
+            '...or try other album solution\n'
+            'sorry for inconvenience :('
+            '\nshortcut exc -> $e';
+      }
     }
     return File(link.path);
   } else {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -106,7 +106,7 @@ packages:
     source: hosted
     version: "3.1.4"
   ffi:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: ffi
       sha256: "13a6ccf6a459a125b3fcdb6ec73bd5ff90822e071207c663bfd1f70062d51d18"
@@ -457,6 +457,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
+  win32:
+    dependency: "direct main"
+    description:
+      name: win32
+      sha256: c0e3a4f7be7dae51d8f152230b86627e3397c1ba8c3fa58e63d44a9f3edc9cef
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,8 @@ dependencies:
   #      ref: fix-windoza-extract-errors
   proper_filesize: ^0.0.2
   unorm_dart: ^0.2.0
+  win32: ^2.0.0
+  ffi: ^1.1.3
 
 dev_dependencies:
   lints: ^2.1.1


### PR DESCRIPTION
When folder names contain emojis (like 💖🤖🚀), the PowerShell Shell.CreateShortcut method has an encoding issue:
https://stackoverflow.com/questions/74728834/copy-the-target-of-a-shortcut-file-lnk-when-the-target-path-contains-emoji-c

After trying different encoding and decoding methods, it was impossible to fix this issue in PowerShell.

Using FFI, which allows interaction with OS APIs (win32 in this case), turned out to be the solution.

The advantage is that it is 10x faster at creating shortcuts than using PowerShell on Windows!

Current Method -> PowerShell (105 seconds) [473 shortcuts]
![image](https://github.com/user-attachments/assets/64229297-a7ad-4e7b-8acb-db628f3fefd0)

New Method -> FFI (12 seconds) [473 shortcuts]
![image](https://github.com/user-attachments/assets/d5f500cb-352c-49aa-a3a3-ab9147460517)

The code doesn't discard the use of PowerShell, if FFI fails to create the shortcut on Windows, it falls back to the old PowerShell method.

This fixes: #389
It also fixes: #276 (because on Windows shortcuts are created with absolute path)