### PR TITLE
Mac OS dual builds

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-13, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -22,7 +22,15 @@ jobs:
           elif [ "$RUNNER_OS" == "Windows" ]; then
             echo "name=gpth-windoza.exe" >> $GITHUB_OUTPUT
           elif [ "$RUNNER_OS" == "macOS" ]; then
-            echo "name=gpth-macos" >> $GITHUB_OUTPUT
+            arch=$(uname -m)
+            if [ "$arch" == "arm64" ]; then
+              echo "name=gpth-macos-arm64" >> $GITHUB_OUTPUT
+            elif [ "$arch" == "x86_64" ]; then
+              echo "name=gpth-macos-intel" >> $GITHUB_OUTPUT
+            else
+              echo "Unknown macOS architecture: $arch" >> $GITHUB_OUTPUT
+              exit 1
+            fi
           else
             echo "Unknown OS: $RUNNER_OS"
             exit 69

--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -28,7 +28,7 @@ jobs:
     needs: make-release
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-13, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -44,7 +44,15 @@ jobs:
           elif [ "$RUNNER_OS" == "Windows" ]; then
             echo "name=gpth-windoza.exe" >> $GITHUB_OUTPUT
           elif [ "$RUNNER_OS" == "macOS" ]; then
-            echo "name=gpth-macos" >> $GITHUB_OUTPUT
+            arch=$(uname -m)
+            if [ "$arch" == "arm64" ]; then
+              echo "name=gpth-macos-arm64" >> $GITHUB_OUTPUT
+            elif [ "$arch" == "x86_64" ]; then
+              echo "name=gpth-macos-intel" >> $GITHUB_OUTPUT
+            else
+              echo "Unknown macOS architecture: $arch" >> $GITHUB_OUTPUT
+              exit 1
+            fi
           else
             echo "Unknown OS: $RUNNER_OS"
             exit 69


### PR DESCRIPTION
There are two types of macOS runners on Github, Intel and ARM64. According to the [documentation](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories), the `macos-latest` label now runs on a VM with an ARM64 architecture while `macos-13` is used for Intel machines. This change makes possible to create executables for both CPU architectures on macOS.

Fixes #310 

Example from my fork:

![image](https://github.com/user-attachments/assets/fd8747b4-5f9d-4eec-bd7c-9dd147c9f3cc)

According to this comment, the Intel version is now working as expected:
https://github.com/TheLastGimbus/GooglePhotosTakeoutHelper/issues/396#issuecomment-2787594600